### PR TITLE
Add confirmations for every option in the script

### DIFF
--- a/main.ps1
+++ b/main.ps1
@@ -11,67 +11,98 @@ catch {
 }
 }
 
-UnPin-App "Microsoft Edge"
-UnPin-App "Microsoft Store"
-UnPin-App "Mail"
+function Confirmation{
+    param ([string]$text)
+
+    $option = Read-Host $text "[y/n]"
+    return $option -eq "y"
+}
+
+# Unpin unused apps from the taskbar
+if (Confirmation "Unpin unused apps") {
+    UnPin-App "Microsoft Edge"
+    UnPin-App "Microsoft Store"
+    UnPin-App "Mail"
+}
 
 # Turns on dark mode for apps and system
-$themesPersonalise = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
-Set-ItemProperty -Path $themesPersonalise -Name "AppsUseLightTheme" -Value 0 -Type Dword
-Set-ItemProperty -Path $themesPersonalise -Name "SystemUsesLightTheme" -Value 0 -Type Dword
+if (Confirmation "Turn on dark mode for apps and system") {
+    $themesPersonalise = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+    Set-ItemProperty -Path $themesPersonalise -Name "AppsUseLightTheme" -Value 0 -Type Dword
+    Set-ItemProperty -Path $themesPersonalise -Name "SystemUsesLightTheme" -Value 0 -Type Dword
+}
 
 $explorer = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced"
+
 # Remove task view
-Set-ItemProperty -Path $explorer -Name "ShowTaskViewButton" -Value 0
+if (Confirmation "Remove task view") {
+    Set-ItemProperty -Path $explorer -Name "ShowTaskViewButton" -Value 0
+}
 
 # Turn on file extensions in File Explorer
-Set-ItemProperty -Path $explorer -Name "HideFileExt" -Value 0
+if (Confirmation "Turn on file extensions in File Explorer") {
+    Set-ItemProperty -Path $explorer -Name "HideFileExt" -Value 0
+}
 
 # Hide desktop icons
-Set-ItemProperty -Path $explorer -Name "HideIcons" -Value 1
+if (Confirmation "Hide desktop icons") {
+    Set-ItemProperty -Path $explorer -Name "HideIcons" -Value 1
+}
 
 # Enable seconds in clock
-Set-ItemProperty -Path $explorer -Name "ShowSecondsInSystemClock" -Value 1 -Force
+if (Confirmation "Enable seconds on clock") {
+    Set-ItemProperty -Path $explorer -Name "ShowSecondsInSystemClock" -Value 1 -Force
+}
 
 # Enable 12 hour time in clock
-Set-ItemProperty -Path $explorer -Name "UseWin32TrayClockExperience" -Value 0 -Force
+if (Confirmation "Enable 12 hour time in clock") {
+    Set-ItemProperty -Path $explorer -Name "UseWin32TrayClockExperience" -Value 0 -Force
+}
 
 # Enable the clipboard history
-Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Clipboard" -Name "EnableClipboardHistory" -Value 1
+if (Confirmation "Enable clipboard history") {
+    Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Clipboard" -Name "EnableClipboardHistory" -Value 1
+}
 
 # Set print screen to open snipping tool
-Set-ItemProperty -Path "HKCU:\Control Panel\Keyboard" -Name "PrintScreenKeyForSnippingEnabled" -Value 1 -Type Dword
+if (Confirmation "Rebind print screen to open snipping tool") {
+    Set-ItemProperty -Path "HKCU:\Control Panel\Keyboard" -Name "PrintScreenKeyForSnippingEnabled" -Value 1 -Type Dword
+}
 
 # Set scroll lines to 7
-Add-Type -TypeDefinition @"
+if (Confirmation "Set scroll lines to 7") {
+    Add-Type -TypeDefinition @"
 using System;
 using System.Runtime.InteropServices;
 
 public class WinAPI {
-	[DllImport("user32.dll", SetLastError = true)]
-	public static extern IntPtr SendMessageTimeout(IntPtr hWnd, int Msg, IntPtr wParam, string lParam, uint fuFlags, uint uTimeout, IntPtr lpdwResult);
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr SendMessageTimeout(IntPtr hWnd, int Msg, IntPtr wParam, string lParam, uint fuFlags, uint uTimeout, IntPtr lpdwResult);
 
-	[DllImport("user32.dll", SetLastError = true)]
-	public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, uint pvParam, uint fWinIni);
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, uint pvParam, uint fWinIni);
 }
 "@
 
-$scrollSpeed = 7
-Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "WheelScrollLines" -Value $scrollSpeed
-[WinAPI]::SystemParametersInfo(0x0069, $scrollSpeed, 0, 2)
-[WinAPI]::SendMessageTimeout(0xffff, 0x1a, [IntPtr]::Zero, "Environment", 2, 5000, [IntPtr]::Zero)
+    $scrollSpeed = 7
+    Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "WheelScrollLines" -Value $scrollSpeed
+    [WinAPI]::SystemParametersInfo(0x0069, $scrollSpeed, 0, 2)
+    [WinAPI]::SendMessageTimeout(0xffff, 0x1a, [IntPtr]::Zero, "Environment", 2, 5000, [IntPtr]::Zero)
+}
 
 # Setup edge redirect - https://github.com/rcmaehl/MSEdgeRedirect/wiki/Deploying-MSEdgeRedirect
-Invoke-WebRequest "https://github.com/rcmaehl/MSEdgeRedirect/releases/latest/download/MSEdgeRedirect.exe" -OutFile .\MSEdgeRedirect.exe
-Invoke-WebRequest "https://raw.githubusercontent.com/likes-gay/win-config/main/edge_redirect.ini" -OutFile .\edge_redirect.ini
-Start-Process "MSEdgeRedirect.exe" -ArgumentList "/silentinstall",".\edge_redirect.ini" -PassThru
-Remove-Item -Path ".\edge_redirect.ini"
-Remove-Item -Path ".\MSEdgeRedirect.exe"
+if (Confirmation "Install and configure MSEdgeRedirect") {
+    Invoke-WebRequest "https://github.com/rcmaehl/MSEdgeRedirect/releases/latest/download/MSEdgeRedirect.exe" -OutFile .\MSEdgeRedirect.exe
+    Invoke-WebRequest "https://raw.githubusercontent.com/likes-gay/win-config/main/edge_redirect.ini" -OutFile .\edge_redirect.ini
+    Start-Process "MSEdgeRedirect.exe" -ArgumentList "/silentinstall",".\edge_redirect.ini" -PassThru
+    Remove-Item -Path ".\edge_redirect.ini"
+    Remove-Item -Path ".\MSEdgeRedirect.exe"
+}
 
 try {
-	Stop-Process -Name msedge -Force
+    Stop-Process -Name msedge -Force
 } catch {
-	Write-Output "Microsoft Edge is already shut"
+    Write-Output "Microsoft Edge is already shut"
 }
 
 try {

--- a/main.ps1
+++ b/main.ps1
@@ -11,11 +11,23 @@ catch {
 }
 }
 
+# Override for the confirm function
+$confirmOverride = false
+
 function Confirmation{
 	param ([string]$text)
 
+	if ($confirmOverride) {
+		return true
+ 	}
+
 	$option = Read-Host $text "[y/n]"
 	return $option -eq "y"
+}
+
+# Option to accept all the options
+if (Confirmation "Apply all options") {
+	$confirmOverride = true
 }
 
 # Unpin unused apps from the taskbar

--- a/main.ps1
+++ b/main.ps1
@@ -12,97 +12,97 @@ catch {
 }
 
 function Confirmation{
-    param ([string]$text)
+	param ([string]$text)
 
-    $option = Read-Host $text "[y/n]"
-    return $option -eq "y"
+	$option = Read-Host $text "[y/n]"
+	return $option -eq "y"
 }
 
 # Unpin unused apps from the taskbar
 if (Confirmation "Unpin unused apps") {
-    UnPin-App "Microsoft Edge"
-    UnPin-App "Microsoft Store"
-    UnPin-App "Mail"
+	UnPin-App "Microsoft Edge"
+	UnPin-App "Microsoft Store"
+	UnPin-App "Mail"
 }
 
 # Turns on dark mode for apps and system
 if (Confirmation "Turn on dark mode for apps and system") {
-    $themesPersonalise = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
-    Set-ItemProperty -Path $themesPersonalise -Name "AppsUseLightTheme" -Value 0 -Type Dword
-    Set-ItemProperty -Path $themesPersonalise -Name "SystemUsesLightTheme" -Value 0 -Type Dword
+	$themesPersonalise = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+	Set-ItemProperty -Path $themesPersonalise -Name "AppsUseLightTheme" -Value 0 -Type Dword
+	Set-ItemProperty -Path $themesPersonalise -Name "SystemUsesLightTheme" -Value 0 -Type Dword
 }
 
 $explorer = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced"
 
 # Remove task view
 if (Confirmation "Remove task view") {
-    Set-ItemProperty -Path $explorer -Name "ShowTaskViewButton" -Value 0
+	Set-ItemProperty -Path $explorer -Name "ShowTaskViewButton" -Value 0
 }
 
 # Turn on file extensions in File Explorer
 if (Confirmation "Turn on file extensions in File Explorer") {
-    Set-ItemProperty -Path $explorer -Name "HideFileExt" -Value 0
+	Set-ItemProperty -Path $explorer -Name "HideFileExt" -Value 0
 }
 
 # Hide desktop icons
 if (Confirmation "Hide desktop icons") {
-    Set-ItemProperty -Path $explorer -Name "HideIcons" -Value 1
+	Set-ItemProperty -Path $explorer -Name "HideIcons" -Value 1
 }
 
 # Enable seconds in clock
 if (Confirmation "Enable seconds on clock") {
-    Set-ItemProperty -Path $explorer -Name "ShowSecondsInSystemClock" -Value 1 -Force
+	Set-ItemProperty -Path $explorer -Name "ShowSecondsInSystemClock" -Value 1 -Force
 }
 
 # Enable 12 hour time in clock
 if (Confirmation "Enable 12 hour time in clock") {
-    Set-ItemProperty -Path $explorer -Name "UseWin32TrayClockExperience" -Value 0 -Force
+	Set-ItemProperty -Path $explorer -Name "UseWin32TrayClockExperience" -Value 0 -Force
 }
 
 # Enable the clipboard history
 if (Confirmation "Enable clipboard history") {
-    Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Clipboard" -Name "EnableClipboardHistory" -Value 1
+	Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Clipboard" -Name "EnableClipboardHistory" -Value 1
 }
 
 # Set print screen to open snipping tool
 if (Confirmation "Rebind print screen to open snipping tool") {
-    Set-ItemProperty -Path "HKCU:\Control Panel\Keyboard" -Name "PrintScreenKeyForSnippingEnabled" -Value 1 -Type Dword
+	Set-ItemProperty -Path "HKCU:\Control Panel\Keyboard" -Name "PrintScreenKeyForSnippingEnabled" -Value 1 -Type Dword
 }
 
 # Set scroll lines to 7
 if (Confirmation "Set scroll lines to 7") {
-    Add-Type -TypeDefinition @"
+	Add-Type -TypeDefinition @"
 using System;
 using System.Runtime.InteropServices;
 
 public class WinAPI {
-    [DllImport("user32.dll", SetLastError = true)]
-    public static extern IntPtr SendMessageTimeout(IntPtr hWnd, int Msg, IntPtr wParam, string lParam, uint fuFlags, uint uTimeout, IntPtr lpdwResult);
+	[DllImport("user32.dll", SetLastError = true)]
+	public static extern IntPtr SendMessageTimeout(IntPtr hWnd, int Msg, IntPtr wParam, string lParam, uint fuFlags, uint uTimeout, IntPtr lpdwResult);
 
-    [DllImport("user32.dll", SetLastError = true)]
-    public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, uint pvParam, uint fWinIni);
+	[DllImport("user32.dll", SetLastError = true)]
+	public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, uint pvParam, uint fWinIni);
 }
 "@
 
-    $scrollSpeed = 7
-    Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "WheelScrollLines" -Value $scrollSpeed
-    [WinAPI]::SystemParametersInfo(0x0069, $scrollSpeed, 0, 2)
-    [WinAPI]::SendMessageTimeout(0xffff, 0x1a, [IntPtr]::Zero, "Environment", 2, 5000, [IntPtr]::Zero)
+	$scrollSpeed = 7
+	Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "WheelScrollLines" -Value $scrollSpeed
+	[WinAPI]::SystemParametersInfo(0x0069, $scrollSpeed, 0, 2)
+	[WinAPI]::SendMessageTimeout(0xffff, 0x1a, [IntPtr]::Zero, "Environment", 2, 5000, [IntPtr]::Zero)
 }
 
 # Setup edge redirect - https://github.com/rcmaehl/MSEdgeRedirect/wiki/Deploying-MSEdgeRedirect
 if (Confirmation "Install and configure MSEdgeRedirect") {
-    Invoke-WebRequest "https://github.com/rcmaehl/MSEdgeRedirect/releases/latest/download/MSEdgeRedirect.exe" -OutFile .\MSEdgeRedirect.exe
-    Invoke-WebRequest "https://raw.githubusercontent.com/likes-gay/win-config/main/edge_redirect.ini" -OutFile .\edge_redirect.ini
-    Start-Process "MSEdgeRedirect.exe" -ArgumentList "/silentinstall",".\edge_redirect.ini" -PassThru
-    Remove-Item -Path ".\edge_redirect.ini"
-    Remove-Item -Path ".\MSEdgeRedirect.exe"
+	Invoke-WebRequest "https://github.com/rcmaehl/MSEdgeRedirect/releases/latest/download/MSEdgeRedirect.exe" -OutFile .\MSEdgeRedirect.exe
+	Invoke-WebRequest "https://raw.githubusercontent.com/likes-gay/win-config/main/edge_redirect.ini" -OutFile .\edge_redirect.ini
+	Start-Process "MSEdgeRedirect.exe" -ArgumentList "/silentinstall",".\edge_redirect.ini" -PassThru
+	Remove-Item -Path ".\edge_redirect.ini"
+	Remove-Item -Path ".\MSEdgeRedirect.exe"
 }
 
 try {
-    Stop-Process -Name msedge -Force
+	Stop-Process -Name msedge -Force
 } catch {
-    Write-Output "Microsoft Edge is already shut"
+	Write-Output "Microsoft Edge is already shut"
 }
 
 try {
@@ -127,17 +127,17 @@ $images = (Invoke-WebRequest "https://raw.githubusercontent.com/likes-gay/win-co
 # Create folder to store downloaded images in to prevent clutter.
 $downloadPath = $env:USERPROFILE + "\Downloads\likes-gay-images"
 If (!(test-path $downloadPath)) {
-    New-Item -ItemType Directory -Path $downloadPath
+	New-Item -ItemType Directory -Path $downloadPath
 }
 
 foreach ($i in $images) {
-    # Get the name of the image from the URL
-    # Windows will not open images in the photo viewer unless they have a file extension.
-    $imageName = $i.split("/")[$i.split("/").Count - 1]
+	# Get the name of the image from the URL
+	# Windows will not open images in the photo viewer unless they have a file extension.
+	$imageName = $i.split("/")[$i.split("/").Count - 1]
 
-    # Download and open the image
-    Invoke-WebRequest -Uri $i -OutFile $downloadPath\$imageName
-    Start-Process $downloadPath\$imageName
+	# Download and open the image
+	Invoke-WebRequest -Uri $i -OutFile $downloadPath\$imageName
+	Start-Process $downloadPath\$imageName
 }
 
 exit


### PR DESCRIPTION
Added yes or no confirmations for most parts of the script, maintains the speed of the script whilst allowing most user customisation.

```ps1
try {
    Stop-Process -Name msedge -Force
} catch {
    Write-Output "Microsoft Edge is already shut"
}

try {
	Stop-Process -Name Teams -Force
} catch {
	Write-Output "Microsoft Teams is already shut"
}
```
This is the only part without a confirmation because I'm not sure what its for.


![image](https://github.com/likes-gay/win-config/assets/104585393/eb009f3d-c889-4163-8f58-cd7a4606be6f)