### PR TITLE
Deprecate the exe builder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: publish-exe
+name: publish-ps1
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
       - "*.ps1"
 
 jobs:    
-  ps1-to-exe:
+  publish-ps1:
     runs-on: windows-latest
     
     permissions:
@@ -17,19 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Ps2exe
-        shell: powershell
-        run: Install-Module ps2exe -force
-
-      - name: Compile
-        shell: powershell
-        run: Invoke-ps2exe .\main.ps1 .\likes-gay-config.exe
-      
       - name: Publish
         uses: softprops/action-gh-release@v2.2.1
         with:
           files: |
-            likes-gay-config.exe
             main.ps1
           tag_name: v${{ github.run_number }}
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ It works by finding their config based off of the computer's username.
 iwr "https://github.com/likes-gay/win-config/releases/latest/download/main.ps1" -OutFile main.ps1; .\main.ps1
 ```
 
-### Legacy CMD command
-
-```cmd
-curl -L -o likes-gay-config.exe https://github.com/likes-gay/win-config/releases/latest/download/likes-gay-config.exe && likes-gay-config.exe && del likes-gay-config.exe
-```
-
 ## Using a Rubber Ducky (badusb) to run the script
 
 Upload the [`payload.dd`](https://github.com/likes-gay/win-config/blob/main/payload.dd) to your USB


### PR DESCRIPTION
Fixes #25

Deprecate the exe builder and update references to the PowerShell script.

* Remove the exe builder steps from `.github/workflows/publish.yml`.
* Ensure the workflow continues to publish the PowerShell script.
* Update `README.md` to remove the legacy CMD command and reference the PowerShell script download URL.